### PR TITLE
fix: ESM専用パッケージのdefault import廃止に対応

### DIFF
--- a/js/bin/main.js
+++ b/js/bin/main.js
@@ -2,10 +2,10 @@
 import { createRequire } from 'module';
 import chokidar from 'chokidar';
 import parseArgs from 'minimist';
-import mkdirp from 'mkdirp';
+import { mkdirp } from 'mkdirp';
 import path from 'path';
 import fs from 'fs';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import JsToTkcode from '../lib/js-to-tkcode.js';
 import md5 from 'md5';
 import md5File from 'md5-file';

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "md5-file": "^5.0.0",
         "minimist": "^1.2.5",
         "mithril": "^2.3.8",
-        "mkdirp": "^1.0.4",
+        "mkdirp": "^3.0.1",
         "p-limit": "^7.3.1",
         "path": "^0.12.7",
         "sqlite3": "^6.0.1"
@@ -29,7 +29,6 @@
       },
       "devDependencies": {
         "c8": "^12.0.0",
-        "diff": "^8.0.4",
         "karma": "^6.3.9",
         "karma-chrome-launcher": "^3.2.0",
         "karma-mocha": "^2.0.1",
@@ -1646,16 +1645,6 @@
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
-    },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/diff-match-patch": {
       "version": "1.0.4",
@@ -3448,14 +3437,18 @@
       "integrity": "sha512-za/Yo7qXEckjm5syrSfaaI9Utf4tCUT3T1IOIYqH6Lrj7G0OZuYYLAY9SV4ygoaAf0+CNqU92MBt+7pmo53JVQ=="
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -6957,12 +6950,6 @@
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
     },
-    "diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true
-    },
     "diff-match-patch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
@@ -8198,9 +8185,9 @@
       "integrity": "sha512-za/Yo7qXEckjm5syrSfaaI9Utf4tCUT3T1IOIYqH6Lrj7G0OZuYYLAY9SV4ygoaAf0+CNqU92MBt+7pmo53JVQ=="
     },
     "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
     },
     "mkdirp-classic": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,13 @@
     "md5-file": "^5.0.0",
     "minimist": "^1.2.5",
     "mithril": "^2.3.8",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^3.0.1",
     "p-limit": "^7.3.1",
     "path": "^0.12.7",
     "sqlite3": "^6.0.1"
   },
   "devDependencies": {
     "c8": "^12.0.0",
-    "diff": "^8.0.4",
     "karma": "^6.3.9",
     "karma-chrome-launcher": "^3.2.0",
     "karma-mocha": "^2.0.1",

--- a/test/bin/smoke.test.js
+++ b/test/bin/smoke.test.js
@@ -1,0 +1,36 @@
+import assert from 'power-assert';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const mainPath = fileURLToPath(new URL('../../js/bin/main.js', import.meta.url));
+
+// import の解決失敗を示すエラー。依存が ESM 専用化したり default export を
+// 廃止したりすると、CLI はモジュール読み込みの時点で起動できなくなる。
+const IMPORT_ERROR =
+  /does not provide an export named|ERR_MODULE_NOT_FOUND|ERR_REQUIRE_ESM|Cannot find package/;
+
+describe('js2tk CLI の起動スモーク', () => {
+  it('全ての import が解決でき、設定ファイルの読み込みまで到達すること', function () {
+    this.timeout(20000);
+
+    // 設定ファイルが存在しない一時ディレクトリで起動する。import が全て解決
+    // できていれば js2tk.config.js を探しに行き、そこで初めて失敗する。
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'js2tk-smoke-'));
+    const result = spawnSync(process.execPath, [mainPath], {
+      cwd,
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+
+    assert(
+      !IMPORT_ERROR.test(output),
+      `import の解決に失敗している:\n${output.slice(0, 800)}`
+    );
+    // 設定ファイル探索まで到達した＝全ての import が解決できている
+    assert(/Cannot find module .*js2tk\.config\.js/.test(output));
+  });
+});


### PR DESCRIPTION
## 背景

`js/bin/main.js` が **現在の master 時点で既に起動できない状態**になっていた。

7/25 にマージした js-yaml v5（#46 / #50）で default export が廃止されたため、`import yaml from 'js-yaml'` がモジュール読み込みの時点で `SyntaxError` になる。CI は `mocha` のみで `js/bin/main.js` を一切読み込まないため、この破損が検出されずにマージされていた。

同じ理由で **#53（mkdirp 1.0.4 → 3.0.1）もそのままマージすると起動不能**になる（mkdirp は v2 で default export を廃止し named export のみになっている）。

## 変更内容

- `js/bin/main.js` の import を修正
  - `import yaml from 'js-yaml'` → `import * as yaml from 'js-yaml'`
  - `import mkdirp from 'mkdirp'` → `import { mkdirp } from 'mkdirp'`
- `mkdirp` を `^3.0.1` に更新（#53 相当）
- 未使用の `diff` を devDependencies から削除（コード内に参照なし。#52 は本PRで不要になる）
- `test/bin/smoke.test.js` を追加

## スモークテストについて

設定ファイルが無い一時ディレクトリで CLI を起動し、`js2tk.config.js` の探索まで到達することを確認する。到達した＝全ての import が解決できた証明になる。

| 状態 | 出力 |
| --- | --- |
| 破損時 | `SyntaxError: The requested module 'mkdirp' does not provide an export named 'default'` |
| 正常時 | `Error: Cannot find module '.../js2tk.config.js'` |

意図的に import を壊すとこのテストが落ちることも確認済み。

## 検証

- `npm ci` 通過（lockfile 整合性 OK）
- `npm run test:ci` → 552 passing
- `makeDir()` は戻り値を使わず Promise として await するだけなので、mkdirp v1 → v3 で挙動は変わらない

## 関連

- Closes #52
- Closes #53